### PR TITLE
feat: migrate deploy workflow to NuGet trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,20 +50,25 @@ jobs:
       name: "Production"
       url: "https://www.nuget.org/packages/VS.TestPlaylistTools"
     name: Push NuGets
+    permissions:
+      id-token: write   # Required for OIDC token (NuGet trusted publishing)
+      contents: read
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: NuGet
+
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}  # nuget.org profile name (NOT email)
 
       - name: Push NuGet
         run: |
           $tagVersion = "${{ github.ref }}".substring(11)
-          echo "::set-output name=TAG_VERSION::$tagVersion"
-          dotnet nuget push VSTestPlaylistTools.V1Playlist.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-          dotnet nuget push VSTestPlaylistTools.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-          dotnet nuget push VSTestPlaylistTools.V2Playlist.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-          dotnet nuget push VSTestPlaylistTools.TrxToPlaylistConverter.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-          dotnet nuget push trx-to-vsplaylist.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-        id: tag-version
+          dotnet nuget push VSTestPlaylistTools.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --skip-duplicate
+          dotnet nuget push VSTestPlaylistTools.TrxToPlaylistConverter.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --skip-duplicate
+          dotnet nuget push trx-to-vsplaylist.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --skip-duplicate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,7 @@ jobs:
     permissions:
       id-token: write   # Required for OIDC token (NuGet trusted publishing)
       contents: read
+      actions: read     # Required for actions/download-artifact
 
     steps:
       - name: Download artifact from build job


### PR DESCRIPTION
## Summary

Migrates the NuGet publish workflow from long-lived API keys to OIDC-based trusted publishing via `NuGet/login@v1`. No more secrets to rotate or leak.

## Changes

- **Add `id-token: write` permission** to the `deploy` job (required for OIDC token exchange)
- **Add `NuGet/login@v1` step** — exchanges OIDC token for a short-lived NuGet API key
- **Replace `secrets.NUGET_API_KEY`** with `steps.login.outputs.NUGET_API_KEY` in all push commands
- **Remove V1Playlist and V2Playlist push lines** — these packages were consolidated into `VSTestPlaylistTools` in #75
- **Remove deprecated `::set-output` syntax**
- **Upgrade `actions/download-artifact`** from `v7` → `v8`

## Setup Required Before Merging

1. **Create a trusted publishing policy** on [nuget.org/account/trustedpublishing](https://www.nuget.org/account/trustedpublishing):
   - Repository Owner: `BenjaminMichaelis`
   - Repository: `VS.TestPlaylistTools`
   - Workflow File: `deploy.yml`
   - Environment: `Production`

2. **Add `NUGET_USER` secret** to the `Production` GitHub environment (Settings → Environments → Production):
   - Name: `NUGET_USER`
   - Value: your nuget.org **username** (not email)

3. After the first successful publish, the old `NUGET_API_KEY` secret can be removed.
