### PR TITLE
feat: package trx-to-vsplaylist as RID-specific self-contained tool

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,17 @@ jobs:
       - name: Push NuGet
         run: |
           $tagVersion = "${{ github.ref }}".substring(11)
-          dotnet nuget push VSTestPlaylistTools.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --skip-duplicate
-          dotnet nuget push VSTestPlaylistTools.TrxToPlaylistConverter.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --skip-duplicate
-          dotnet nuget push trx-to-vsplaylist.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --skip-duplicate
+          $source = "https://api.nuget.org/v3/index.json"
+          $apiKey = "${{ steps.login.outputs.NUGET_API_KEY }}"
+
+          dotnet nuget push VSTestPlaylistTools.$tagVersion.nupkg --source $source --api-key $apiKey --skip-duplicate
+          dotnet nuget push VSTestPlaylistTools.TrxToPlaylistConverter.$tagVersion.nupkg --source $source --api-key $apiKey --skip-duplicate
+
+          # Push RID-specific packages before the top-level pointer package.
+          # This ordering is required: the top-level package references the RID packages,
+          # so they must exist on the feed first.
+          # https://learn.microsoft.com/dotnet/core/tools/rid-specific-tools#publish-your-tool
+          foreach ($rid in @('win-x64', 'win-arm64', 'linux-x64', 'linux-arm64', 'osx-x64', 'osx-arm64')) {
+            dotnet nuget push "trx-to-vsplaylist.$rid.$tagVersion.nupkg" --source $source --api-key $apiKey --skip-duplicate
+          }
+          dotnet nuget push trx-to-vsplaylist.$tagVersion.nupkg --source $source --api-key $apiKey --skip-duplicate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,8 @@ jobs:
           # This ordering is required: the top-level package references the RID packages,
           # so they must exist on the feed first.
           # https://learn.microsoft.com/dotnet/core/tools/rid-specific-tools#publish-your-tool
-          foreach ($rid in @('win-x64', 'win-arm64', 'linux-x64', 'linux-arm64', 'osx-x64', 'osx-arm64')) {
-            dotnet nuget push "trx-to-vsplaylist.$rid.$tagVersion.nupkg" --source $source --api-key $apiKey --skip-duplicate
+          # Discover packages dynamically so the workflow stays in sync with the csproj RID list.
+          Get-ChildItem "trx-to-vsplaylist.*.*.nupkg" | Where-Object { $_.Name -notmatch "^trx-to-vsplaylist\.\d" } | ForEach-Object {
+            dotnet nuget push $_.Name --source $source --api-key $apiKey --skip-duplicate
           }
           dotnet nuget push trx-to-vsplaylist.$tagVersion.nupkg --source $source --api-key $apiKey --skip-duplicate

--- a/trx-to-vsplaylist/trx-to-vsplaylist.csproj
+++ b/trx-to-vsplaylist/trx-to-vsplaylist.csproj
@@ -19,8 +19,13 @@
     <!-- Self-contained packages for common platforms (no .NET runtime required).
          https://learn.microsoft.com/dotnet/core/tools/rid-specific-tools -->
     <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
-    <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</ToolPackageRuntimeIdentifiers>
-    <!-- The top-level pointer package has no binary content; suppress empty snupkg creation -->
+    <!-- Derive tool RIDs from RuntimeIdentifiers to keep them in sync -->
+    <ToolPackageRuntimeIdentifiers>$(RuntimeIdentifiers)</ToolPackageRuntimeIdentifiers>
+  </PropertyGroup>
+
+  <!-- The top-level pointer package has no binary content; suppress empty snupkg only for that build.
+       RID-specific packages (RuntimeIdentifier is set) retain symbols from Directory.Build.props. -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
   

--- a/trx-to-vsplaylist/trx-to-vsplaylist.csproj
+++ b/trx-to-vsplaylist/trx-to-vsplaylist.csproj
@@ -19,9 +19,9 @@
     <!-- Self-contained packages for common platforms (no .NET runtime required).
          https://learn.microsoft.com/dotnet/core/tools/rid-specific-tools
          RuntimeIdentifiers drives cross-compilation of the 6 explicit RID packages.
-         ToolPackageRuntimeIdentifiers adds the 'any' CoreCLR fallback so users on
-         unlisted platforms (linux-musl, win-arm32, FreeBSD, etc.) can still install
-         the tool. The 'any' package is produced separately via 'dotnet pack -r any'. -->
+         'any' is included as a portable CoreCLR fallback (not self-contained) for
+         unlisted platforms (linux-musl, win-arm32, FreeBSD, etc.); all 8 packages
+         are produced by a single 'dotnet pack' invocation. -->
     <RuntimeIdentifiers>any;win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <ToolPackageRuntimeIdentifiers>$(RuntimeIdentifiers)</ToolPackageRuntimeIdentifiers>
   </PropertyGroup>

--- a/trx-to-vsplaylist/trx-to-vsplaylist.csproj
+++ b/trx-to-vsplaylist/trx-to-vsplaylist.csproj
@@ -31,6 +31,11 @@
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 
+  <!-- Explicit RID packages must be self-contained so users don't need .NET installed. -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != '' And '$(RuntimeIdentifier)' != 'any'">
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+
   <!-- The top-level pointer package has no binary content; suppress empty snupkg only for that build.
        RID-specific packages (RuntimeIdentifier is set) retain symbols from Directory.Build.props. -->
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">

--- a/trx-to-vsplaylist/trx-to-vsplaylist.csproj
+++ b/trx-to-vsplaylist/trx-to-vsplaylist.csproj
@@ -17,10 +17,11 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>trx-to-vsplaylist</ToolCommandName>
     <!-- Self-contained packages for common platforms (no .NET runtime required).
-         https://learn.microsoft.com/dotnet/core/tools/rid-specific-tools -->
+         https://learn.microsoft.com/dotnet/core/tools/rid-specific-tools
+         ToolPackageRuntimeIdentifiers is omitted: for CoreCLR self-contained tools,
+         the SDK derives it automatically from RuntimeIdentifiers. It is only needed
+         for AOT builds where each platform is packed separately on its native OS. -->
     <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
-    <!-- Derive tool RIDs from RuntimeIdentifiers to keep them in sync -->
-    <ToolPackageRuntimeIdentifiers>$(RuntimeIdentifiers)</ToolPackageRuntimeIdentifiers>
   </PropertyGroup>
 
   <!-- The top-level pointer package has no binary content; suppress empty snupkg only for that build.

--- a/trx-to-vsplaylist/trx-to-vsplaylist.csproj
+++ b/trx-to-vsplaylist/trx-to-vsplaylist.csproj
@@ -9,12 +9,19 @@
   <!-- 
     For packaging as a dotnet global tool 
     https://learn.microsoft.com/dotnet/core/tools/global-tools-how-to-create
+    https://learn.microsoft.com/dotnet/core/tools/rid-specific-tools
   -->
   
   <PropertyGroup>
     <PackageId>trx-to-vsplaylist</PackageId>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>trx-to-vsplaylist</ToolCommandName>
+    <!-- Self-contained packages for common platforms (no .NET runtime required).
+         https://learn.microsoft.com/dotnet/core/tools/rid-specific-tools -->
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <ToolPackageRuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</ToolPackageRuntimeIdentifiers>
+    <!-- The top-level pointer package has no binary content; suppress empty snupkg creation -->
+    <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
   
     <ItemGroup>

--- a/trx-to-vsplaylist/trx-to-vsplaylist.csproj
+++ b/trx-to-vsplaylist/trx-to-vsplaylist.csproj
@@ -18,10 +18,17 @@
     <ToolCommandName>trx-to-vsplaylist</ToolCommandName>
     <!-- Self-contained packages for common platforms (no .NET runtime required).
          https://learn.microsoft.com/dotnet/core/tools/rid-specific-tools
-         ToolPackageRuntimeIdentifiers is omitted: for CoreCLR self-contained tools,
-         the SDK derives it automatically from RuntimeIdentifiers. It is only needed
-         for AOT builds where each platform is packed separately on its native OS. -->
-    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+         RuntimeIdentifiers drives cross-compilation of the 6 explicit RID packages.
+         ToolPackageRuntimeIdentifiers adds the 'any' CoreCLR fallback so users on
+         unlisted platforms (linux-musl, win-arm32, FreeBSD, etc.) can still install
+         the tool. The 'any' package is produced separately via 'dotnet pack -r any'. -->
+    <RuntimeIdentifiers>any;win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <ToolPackageRuntimeIdentifiers>$(RuntimeIdentifiers)</ToolPackageRuntimeIdentifiers>
+  </PropertyGroup>
+
+  <!-- The 'any' RID is a portable fallback; it must not be self-contained. -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'any'">
+    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <!-- The top-level pointer package has no binary content; suppress empty snupkg only for that build.


### PR DESCRIPTION
## Problem

Users installing `trx-to-vsplaylist` via `dotnet tool install -g trx-to-vsplaylist` currently need .NET 10 installed on their machine to run the tool.

## Solution

Use the [RID-specific tool packaging feature](https://learn.microsoft.com/dotnet/core/tools/rid-specific-tools) introduced in .NET SDK 10 to produce self-contained packages for all common platforms. Users on those platforms get a bundled runtime — no .NET installation required.

`dotnet pack` now produces 7 packages from a single command:

| Package | Platform | .NET required? |
|---|---|---|
| `trx-to-vsplaylist.win-x64` | Windows x64 | ❌ No |
| `trx-to-vsplaylist.win-arm64` | Windows ARM64 | ❌ No |
| `trx-to-vsplaylist.linux-x64` | Linux x64 | ❌ No |
| `trx-to-vsplaylist.linux-arm64` | Linux ARM64 | ❌ No |
| `trx-to-vsplaylist.osx-x64` | macOS Intel | ❌ No |
| `trx-to-vsplaylist.osx-arm64` | macOS Apple Silicon | ❌ No |
| `trx-to-vsplaylist` | Top-level pointer | n/a |

Users still install with `dotnet tool install -g trx-to-vsplaylist` — the CLI picks the right package automatically.

## Changes

### `trx-to-vsplaylist/trx-to-vsplaylist.csproj`
- `RuntimeIdentifiers` — enables restore and self-contained publish for the 6 target platforms
- `ToolPackageRuntimeIdentifiers` — scopes RID packaging to the tool, preventing an extra empty non-RID package from being emitted
- `IncludeSymbols=false` — suppresses NU5017 on the top-level pointer package (it has no binary content by design; symbols live in the RID-specific packages)

### `.github/workflows/deploy.yml`
- Push RID-specific packages before the top-level pointer package (required — the pointer references the RID packages, so they must exist on the feed first)
- Minor cleanup: extract `$source` and `$apiKey` variables to reduce repetition

## Notes

- No AOT compilation is used — this is CoreCLR self-contained, so no per-OS CI matrix is needed and no AOT compatibility requirements apply to dependencies (`System.CommandLine`, `TrxLib`, etc.)
- All 89 existing tests pass