### PR TITLE
docs: sync README content with current API and CLI

### DIFF
--- a/PlaylistV1/README.md
+++ b/PlaylistV1/README.md
@@ -1,38 +1,38 @@
-# PlaylistV1 - Visual Studio Test Playlist V1 Parser and Builder
+# PlaylistV1 - Visual Studio Test Playlist V1 parser and builder
 
-This folder contains a clean implementation of a parser and builder for Visual Studio Test Playlist Version 1.0 format.
+This folder documents the V1 API exposed from the `VSTestPlaylistTools` package.
 
 ## Overview
 
-The PlaylistV1 implementation provides functionality to:
+The V1 API provides functionality to:
 - Parse Visual Studio Test Playlist V1.0 XML files
 - Create and build new playlist files programmatically
 - Validate playlist file format
-- Perform round-trip conversions (parse and regenerate identical XML)
+- Perform round-trip conversions (parse and regenerate XML)
 
-## Usage Examples
+## Usage examples
 
-### Parsing a Playlist File
+### Parsing a playlist file
 
 ```csharp
-using PlaylistV1;
+using VS.TestPlaylistTools.PlaylistV1;
 
 // Parse from file
-var playlist = PlaylistV1Parser.ParseFromFile("myplaylist.playlist");
+var playlist = PlaylistV1Parser.FromFile("myplaylist.playlist");
 Console.WriteLine($"Found {playlist.TestCount} tests");
 
 // Parse from string
 string xmlContent = "<Playlist Version=\"1.0\"><Add Test=\"MyTest\" /></Playlist>";
-var playlist2 = PlaylistV1Parser.ParseFromString(xmlContent);
+var playlist2 = PlaylistV1Parser.FromString(xmlContent);
 ```
 
-### Building a Playlist
+### Building a playlist
 
 ```csharp
-using PlaylistV1;
+using VS.TestPlaylistTools.PlaylistV1;
 
 // Create a simple playlist
-var playlist = PlaylistV1Builder.Create("Test1", "Test2", "Test3");
+var playlist = PlaylistV1Builder.Create(["Test1", "Test2", "Test3"]);
 
 // Use fluent builder pattern
 var playlist2 = PlaylistV1Builder.CreateBuilder()
@@ -48,10 +48,12 @@ string xml = PlaylistV1Builder.ToXmlString(playlist);
 PlaylistV1Builder.SaveToFile(playlist, "output.playlist");
 ```
 
-### Working with Playlist Objects
+### Working with playlist objects
 
 ```csharp
-var playlist = new PlaylistV1.Models.PlaylistV1();
+using VS.TestPlaylistTools.PlaylistV1;
+
+var playlist = new PlaylistRoot();
 
 // Add tests
 playlist.AddTest("MyTest1");
@@ -64,7 +66,7 @@ playlist.RemoveTest("MyTest1");
 Console.WriteLine($"Playlist contains {playlist.TestCount} tests");
 ```
 
-## XML Format
+## XML format
 
 The V1 playlist format is simple and consists of:
 
@@ -72,11 +74,10 @@ The V1 playlist format is simple and consists of:
 <Playlist Version="1.0">
     <Add Test="FullyQualifiedTestName1" />
     <Add Test="FullyQualifiedTestName2" />
-    <!-- ... more tests ... -->
 </Playlist>
 ```
 
 Key characteristics:
 - Root element is `<Playlist>` with `Version="1.0"`
 - Each test is represented by an `<Add>` element with a `Test` attribute
-- Test names should be fully qualified (e.g., `Namespace.Class.Method`)
+- Test names should be fully qualified (for example: `Namespace.Class.Method`)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# VS.TestPlaylistTools
+# VS.TestPlaylistTools
 
 A collection of .NET libraries and tools for creating, parsing, and manipulating Visual Studio test playlist files.
 
@@ -11,8 +11,8 @@ A collection of .NET libraries and tools for creating, parsing, and manipulating
 
 ### Libraries
 
-- **[VSTestPlaylistTools](https://www.nuget.org/packages/VSTestPlaylistTools)** - Unified library with playlist loading utilities
-- **[VSTestPlaylistTools.TrxToPlaylistConverter](https://www.nuget.org/packages/VSTestPlaylistTools.TrxToPlaylistConverter)** - Convert TRX test results to playlists
+- **[VSTestPlaylistTools](https://www.nuget.org/packages/VSTestPlaylistTools)** - Playlist V1/V2 types, builders/parsers, and unified loading utilities
+- **[VSTestPlaylistTools.TrxToPlaylistConverter](https://www.nuget.org/packages/VSTestPlaylistTools.TrxToPlaylistConverter)** - Library for converting TRX test results to V1 playlists
 
 ## Quick Start
 
@@ -22,36 +22,45 @@ A collection of .NET libraries and tools for creating, parsing, and manipulating
 
 ### Converting a TRX file to a VS Playlist
 
-`trx-to-vsplaylist input.trx -o output.playlist`
+`trx-to-vsplaylist convert input.trx -o output.playlist`
 
 ### Convert failed tests only
 
-`trx-to-vsplaylist input.trx -o failed.playlist --failed-only`
+`trx-to-vsplaylist convert input.trx -o failed.playlist --outcome Failed`
 
-### Using the V2 Playlist Library
+### Using the V2 Playlist API
 
-`dotnet add package VSTestPlaylistTools.V2Playlist`
+`dotnet add package VSTestPlaylistTools`
 
 ```
 using VS.TestPlaylistTools.PlaylistV2;
-// Create a playlist with rules var playlist = new PlaylistRoot(); playlist.Rules.Add(BooleanRule.Any("MyTests", PropertyRule.Namespace("MyNamespace"), PropertyRule.Trait("Category", "Integration") ));
-// Save to file playlist.SaveToFile("MyPlaylist.playlist");
+
+var playlist = new PlaylistRoot();
+playlist.Rules.Add(
+    BooleanRule.Any(
+        "MyTests",
+        PropertyRule.Namespace("MyNamespace"),
+        PropertyRule.Trait("Category", "Integration")));
+
+PlaylistV2Builder.SaveToFile(playlist, "MyPlaylist.playlist");
 ```
 
-### Using the V1 Playlist Library
+### Using the V1 Playlist API
 
-`dotnet add package VSTestPlaylistTools.V1Playlist`
+`dotnet add package VSTestPlaylistTools`
 
 ```
 using VS.TestPlaylistTools.PlaylistV1;
-// Create a simple V1 playlist var playlist = new Playlist(); playlist.AddTest("MyTest.FullyQualifiedName"); playlist.SaveToFile("MyPlaylist.playlist");
+
+var playlist = PlaylistV1Builder.Create(["MyTest.FullyQualifiedName"]);
+PlaylistV1Builder.SaveToFile(playlist, "MyPlaylist.playlist");
 ```
 
 ## 📚 Documentation
 
-- [PlaylistV2 Documentation](./PlaylistV2/README.md)
+- [PlaylistV2 API Source](./VSTestPlaylistTools/PlaylistV2)
 - [PlaylistV1 Documentation](./PlaylistV1/README.md)
-- [TRX Converter Documentation](./VSTestPlaylistTools.TrxToPlaylistConverter/README.md)
+- [TRX Converter CLI Documentation](./trx-to-vsplaylist/README.md)
 - [Sample Playlists](./PlaylistV2.Tests/SamplePlaylists)
 
 ## 🤝 Contributing


### PR DESCRIPTION
The documentation had drifted from the current implementation, which made quick-start usage and API examples misleading. This updates the core docs so they match the code users run today.

## What changed
- Updated root `README.md` CLI examples to the current command shape (`trx-to-vsplaylist convert ...`) and replaced stale package guidance with `VSTestPlaylistTools`.
- Fixed root documentation links to point to existing locations in the repo.
- Reworked `PlaylistV1/README.md` examples to current namespace and API names (`VS.TestPlaylistTools.PlaylistV1`, `FromFile`/`FromString`, `PlaylistRoot`).
- Cleaned malformed code snippets so examples are copy/paste-safe.

## Notes for reviewers
- This is a docs-only PR focused on accuracy and consistency; no production code paths were changed.