### PR TITLE
build: exclude AOT smoke test project from NuGet packing

### DIFF
--- a/VSTestPlaylistTools.TrxToPlaylistConverter.AotSmokeTest/VSTestPlaylistTools.TrxToPlaylistConverter.AotSmokeTest.csproj
+++ b/VSTestPlaylistTools.TrxToPlaylistConverter.AotSmokeTest/VSTestPlaylistTools.TrxToPlaylistConverter.AotSmokeTest.csproj
@@ -7,6 +7,7 @@
     <ILLinkTreatWarningsAsErrors>true</ILLinkTreatWarningsAsErrors>
     <!-- This project is only published via dotnet publish -r <RID>; exclude from dotnet test -->
     <IsTestProject>false</IsTestProject>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The release pack workflow was trying to include the AOT smoke test project even though it is only used for test/publish validation. That caused package metadata validation to run on a non-release test project.

## What changed
- Marked `VSTestPlaylistTools.TrxToPlaylistConverter.AotSmokeTest` as non-packable with `<IsPackable>false</IsPackable>`.

## Why this approach
This keeps the smoke test project available for AOT validation while preventing it from being emitted as a NuGet package during `dotnet pack`, which aligns packaging output with intended release artifacts.