### PR TITLE
ci: add best-effort artifact attestation for NuGet release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,8 @@ jobs:
       id-token: write   # Required for OIDC token (NuGet trusted publishing)
       contents: read
       actions: read     # Required for actions/download-artifact
+      attestations: write
+      artifact-metadata: write
 
     steps:
       - name: Download artifact from build job
@@ -66,6 +68,12 @@ jobs:
         uses: NuGet/login@v1
         with:
           user: ${{ secrets.NUGET_USER }}  # nuget.org profile name (NOT email)
+
+      - name: Attest NuGet packages (best effort)
+        continue-on-error: true
+        uses: actions/attest@v4
+        with:
+          subject-path: '${{ github.workspace }}/*.nupkg'
 
       - name: Push NuGet
         run: |


### PR DESCRIPTION
NuGet trusted publishing with OIDC is already in place, but the release workflow did not emit GitHub artifact attestations for produced packages. This adds provenance hardening without introducing release risk.

### What changed
- Added `attestations: write` and `artifact-metadata: write` permissions to the deploy job.
- Added an `actions/attest@v4` step to attest all generated `.nupkg` files.
- Made attestation best-effort via `continue-on-error: true` so publish remains non-blocking.

### Notes for reviewers
This is intentionally additive: NuGet OIDC trusted publishing remains unchanged, and package push behavior is preserved even if attestation has a transient failure.